### PR TITLE
ci: Code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --out Xml
+          cargo tarpaulin --verbose --out Xml --all-features --benches --tests --examples --workspace
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Code coverage was being tested only against the root crate, and not the crates in workspaces.